### PR TITLE
Fix two-station K600 units: velocity-scale parameter, depth-normalized daily output

### DIFF
--- a/R/metab_bayes_2s.R
+++ b/R/metab_bayes_2s.R
@@ -215,9 +215,9 @@ metab_bayes_2s <- function(
       #
       # Prepare the Stan data list (matrices from data, plus scalar priors
       # from specs). modifyList (not c()) is used because prepdata_bayes_2s()
-      # already supplies K600_lnorm_meanlog/K600_lnorm_sdlog (read from
-      # specs), and those two names are also in specs$params_in; a plain c()
-      # would create duplicate-named list elements instead of overriding.
+      # already supplies k600_velocity_lnorm_meanlog/sdlog (read from specs),
+      # and those two names are also in specs$params_in; a plain c() would
+      # create duplicate-named list elements instead of overriding.
       #
       # Prepared here, outside bayes_1fit_2s(), so that data problems
       # prepdata_bayes_2s() detects (NA light in an otherwise complete day,
@@ -674,7 +674,8 @@ bayes_perday_2s <- function(data, specs, aln=NULL) {
 #'   include the lead-in rows required to cover the longest travel time (see
 #'   \code{\link{metab_bayes_2s}}).
 #' @param specs a list of model specs (see \code{\link{specs}}), expected to
-#'   already contain \code{K600_lnorm_meanlog} and \code{K600_lnorm_sdlog}
+#'   already contain \code{k600_velocity_lnorm_meanlog} and
+#'   \code{k600_velocity_lnorm_sdlog}
 #'   -- e.g., the object returned by \code{specs(mm_name('bayes_2s'))}, which
 #'   populates them with sensible defaults. This function does not supply
 #'   its own fallback values; if \code{specs} is omitted or missing these
@@ -690,7 +691,8 @@ bayes_perday_2s <- function(data, specs, aln=NULL) {
 #'   \code{n_obs}, \code{n_days}, \code{DO_obs_up}, \code{DO_sat_up},
 #'   \code{DO_obs_down}, \code{DO_sat_down}, \code{light}, \code{depth},
 #'   \code{temp_water}, \code{travel_time} (each an \code{n_obs x n_days}
-#'   matrix, unitless), and \code{K600_lnorm_meanlog}/\code{K600_lnorm_sdlog}
+#'   matrix, unitless), and the velocity-scale gas exchange prior
+#'   \code{k600_velocity_lnorm_meanlog}/\code{k600_velocity_lnorm_sdlog}
 #' @importFrom unitted v
 #' @keywords internal
 prepdata_bayes_2s <- function(data, specs=NULL, aln=NULL) {
@@ -757,8 +759,8 @@ prepdata_bayes_2s <- function(data, specs=NULL, aln=NULL) {
     depth = to_matrix(modeled$depth),
     temp_water = to_matrix(modeled$temp.water),
     travel_time = to_matrix(modeled$travel.time),
-    K600_lnorm_meanlog = specs$K600_lnorm_meanlog,
-    K600_lnorm_sdlog = specs$K600_lnorm_sdlog
+    k600_velocity_lnorm_meanlog = specs$k600_velocity_lnorm_meanlog,
+    k600_velocity_lnorm_sdlog = specs$k600_velocity_lnorm_sdlog
   )
 }
 

--- a/R/specs.R
+++ b/R/specs.R
@@ -250,11 +250,18 @@
 #'   proportional to light (with noise) and is applied to GPP rather than to
 #'   dDO/dt.
 #'
-#' @param K600_lnorm_meanlog hyperparameter for \code{type='bayes_2s'}.
-#'   The mean of a lognormal prior distribution for K600_daily.
-#' @param K600_lnorm_sdlog hyperparameter for \code{type='bayes_2s'}. The
-#'   standard deviation parameter of a lognormal prior distribution for
-#'   K600_daily.
+#' @param k600_velocity_lnorm_meanlog hyperparameter for
+#'   \code{type='bayes_2s'}. The meanlog of a lognormal prior distribution
+#'   for the daily gas exchange velocity (m d^-1), which is held constant
+#'   within a day and divided by each timestep's depth to give the rate of
+#'   reaeration used in the model. The daily mean of that rate is what the
+#'   model reports as K600_daily (d^-1), so this prior is on a different
+#'   quantity than the one-station \code{K600_daily_meanlog} and the two
+#'   take different values.
+#' @param k600_velocity_lnorm_sdlog hyperparameter for
+#'   \code{type='bayes_2s'}. The sdlog (standard deviation parameter) of the
+#'   lognormal prior distribution described for
+#'   \code{k600_velocity_lnorm_meanlog}.
 #' @param max_travel_time_hours for \code{type='bayes_2s'}. The travel-time
 #'   ceiling, in hours: days whose longest \code{travel.time} exceeds this are
 #'   dropped, with a message, rather than modeled (see
@@ -441,17 +448,22 @@ specs <- function(
   err_proc_acor_sigma_scale = 1,
   err_mult_GPP_sdlog_sigma = 1,
 
-  # hyperparameters for two-station (bayes_2s) K600. GPP_daily_mu,
+  # hyperparameters for two-station (bayes_2s) gas exchange. GPP_daily_mu,
   # GPP_daily_sigma, ER_daily_mu, and ER_daily_sigma above are reused as-is.
-  # These are the sole source of the K600 lognormal prior defaults --
-  # prepdata_bayes_2s() reads them from specs$K600_lnorm_meanlog/sdlog
-  K600_lnorm_meanlog = 2.484907,
-  K600_lnorm_sdlog = 1.0,
+  # These are the sole source of the lognormal prior defaults --
+  # prepdata_bayes_2s() reads them from
+  # specs$k600_velocity_lnorm_meanlog/sdlog. The prior is on the
+  # velocity-scale k600 (m d^-1), which the model divides by each timestep's
+  # depth; the reported K600_daily is the resulting daily mean rate (d^-1),
+  # so these are not interchangeable with the one-station
+  # K600_daily_meanlog/sdlog above
+  k600_velocity_lnorm_meanlog = log(3.48),
+  k600_velocity_lnorm_sdlog = 0.5,
 
   # two-station travel-time ceiling, in hours. read by prepdata_bayes_2s() and
   # metab_bayes_2s(), both of which pass it to mm_align_2s(). unlike the
-  # K600_lnorm_* hyperparameters above it is not spliced into the Stan data
-  # list, so it is not part of params_in.
+  # k600_velocity_lnorm_* hyperparameters above it is not spliced into the
+  # Stan data list, so it is not part of params_in.
   max_travel_time_hours = mm_max_travel_time_default,
 
   # two-station gap-filling tolerance, in hours. read by metab_bayes_2s(),
@@ -681,7 +693,7 @@ specs <- function(
       all_specs$params_in <- c(
         'GPP_daily_mu', 'GPP_daily_sigma',
         'ER_daily_mu', 'ER_daily_sigma',
-        'K600_lnorm_meanlog', 'K600_lnorm_sdlog')
+        'k600_velocity_lnorm_meanlog', 'k600_velocity_lnorm_sdlog')
 
       # list all needed arguments
       included <- c(

--- a/inst/models/b2_np_oi_tr_plrckm.stan
+++ b/inst/models/b2_np_oi_tr_plrckm.stan
@@ -15,23 +15,25 @@ data {
   real<lower=0> GPP_daily_sigma;
   real ER_daily_mu;
   real<lower=0> ER_daily_sigma;
-  real K600_lnorm_meanlog;
-  real<lower=0> K600_lnorm_sdlog;
+  real k600_velocity_lnorm_meanlog;
+  real<lower=0> k600_velocity_lnorm_sdlog;
 }
 
 parameters {
   vector<lower=0>[n_days] GPP_daily;
   vector[n_days] ER_daily;
-  vector<lower=0>[n_days] K600_daily;
+  vector<lower=0>[n_days] k600_velocity; // gas exchange velocity, m d^-1, constant within a day
   real<lower=0> sigma;
 }
 
 transformed parameters {
+  array[n_obs] vector[n_days] K600; // rate-scale gas exchange, d^-1
   array[n_obs] vector[n_days] metab;
   array[n_obs] vector[n_days] KO2;
   for (i in 1:n_obs){
     for (t in 1:n_days){
-      KO2[i,t] = (K600_daily[t] / depth[i,t]) / ((600 / (1800.6 - (temp_water[i,t] * 120.1) + (3.7818 * temp_water[i,t]^2) - (0.047608 * temp_water[i,t]^3)))^-0.5);
+      K600[i,t] = k600_velocity[t] / depth[i,t];
+      KO2[i,t] = K600[i,t] / ((600 / (1800.6 - (temp_water[i,t] * 120.1) + (3.7818 * temp_water[i,t]^2) - (0.047608 * temp_water[i,t]^3)))^-0.5);
     }
     metab[i] = (DO_obs_up[i] + GPP_daily .* light[i] ./ depth[i] + ER_daily .* travel_time[i] ./ depth[i] + (KO2[i] .* travel_time[i] .* (DO_sat_up[i] - DO_obs_up[i] + DO_sat_down[i]) / 2)) ./ (1 + (KO2[i] .* travel_time[i]) / 2);
   }
@@ -41,9 +43,22 @@ model {
   GPP_daily ~ normal(GPP_daily_mu, GPP_daily_sigma);
   ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
   for (i in 1:n_days){
-    K600_daily[i] ~ lognormal(K600_lnorm_meanlog, K600_lnorm_sdlog);
+    k600_velocity[i] ~ lognormal(k600_velocity_lnorm_meanlog, k600_velocity_lnorm_sdlog);
   }
   for (i in 1:n_obs){
     DO_obs_down[i] ~ normal(metab[i], sigma);
+  }
+}
+
+generated quantities {
+  // daily mean rate-scale K600, d^-1: divide the day's velocity-scale
+  // k600 by each timestep's depth first, then average over the day
+  vector[n_days] K600_daily;
+  for (t in 1:n_days){
+    real K600_sum = 0;
+    for (i in 1:n_obs){
+      K600_sum += K600[i,t];
+    }
+    K600_daily[t] = K600_sum / n_obs;
   }
 }

--- a/man/prepdata_bayes_2s.Rd
+++ b/man/prepdata_bayes_2s.Rd
@@ -17,7 +17,8 @@ include the lead-in rows required to cover the longest travel time (see
 \code{\link{metab_bayes_2s}}).}
 
 \item{specs}{a list of model specs (see \code{\link{specs}}), expected to
-already contain \code{K600_lnorm_meanlog} and \code{K600_lnorm_sdlog}
+already contain \code{k600_velocity_lnorm_meanlog} and
+\code{k600_velocity_lnorm_sdlog}
 -- e.g., the object returned by \code{specs(mm_name('bayes_2s'))}, which
 populates them with sensible defaults. This function does not supply
 its own fallback values; if \code{specs} is omitted or missing these
@@ -36,7 +37,8 @@ a named list with all variables in the Stan model's data block:
   \code{n_obs}, \code{n_days}, \code{DO_obs_up}, \code{DO_sat_up},
   \code{DO_obs_down}, \code{DO_sat_down}, \code{light}, \code{depth},
   \code{temp_water}, \code{travel_time} (each an \code{n_obs x n_days}
-  matrix, unitless), and \code{K600_lnorm_meanlog}/\code{K600_lnorm_sdlog}
+  matrix, unitless), and the velocity-scale gas exchange prior
+  \code{k600_velocity_lnorm_meanlog}/\code{k600_velocity_lnorm_sdlog}
 }
 \description{
 Time-shifts the upstream DO series to match the travel time between

--- a/man/specs.Rd
+++ b/man/specs.Rd
@@ -55,8 +55,8 @@ specs(
   err_proc_acor_phi_beta = 1,
   err_proc_acor_sigma_scale = 1,
   err_mult_GPP_sdlog_sigma = 1,
-  K600_lnorm_meanlog = 2.484907,
-  K600_lnorm_sdlog = 1,
+  k600_velocity_lnorm_meanlog = log(3.48),
+  k600_velocity_lnorm_sdlog = 0.5,
   max_travel_time_hours = mm_max_travel_time_default,
   max_gap_hours = mm_max_gap_hours_default,
   params_in,
@@ -342,12 +342,19 @@ estimate GPP_inst. The effect is a special kind of process error that is
 proportional to light (with noise) and is applied to GPP rather than to
 dDO/dt.}
 
-\item{K600_lnorm_meanlog}{hyperparameter for \code{type='bayes_2s'}.
-The mean of a lognormal prior distribution for K600_daily.}
+\item{k600_velocity_lnorm_meanlog}{hyperparameter for
+\code{type='bayes_2s'}. The meanlog of a lognormal prior distribution
+for the daily gas exchange velocity (m d^-1), which is held constant
+within a day and divided by each timestep's depth to give the rate of
+reaeration used in the model. The daily mean of that rate is what the
+model reports as K600_daily (d^-1), so this prior is on a different
+quantity than the one-station \code{K600_daily_meanlog} and the two
+take different values.}
 
-\item{K600_lnorm_sdlog}{hyperparameter for \code{type='bayes_2s'}. The
-standard deviation parameter of a lognormal prior distribution for
-K600_daily.}
+\item{k600_velocity_lnorm_sdlog}{hyperparameter for
+\code{type='bayes_2s'}. The sdlog (standard deviation parameter) of the
+lognormal prior distribution described for
+\code{k600_velocity_lnorm_meanlog}.}
 
 \item{max_travel_time_hours}{for \code{type='bayes_2s'}. The travel-time
 ceiling, in hours: days whose longest \code{travel.time} exceeds this are

--- a/tests/testthat/test-metab_bayes_2s.R
+++ b/tests/testthat/test-metab_bayes_2s.R
@@ -169,30 +169,31 @@ test_that("output matrices have n_obs x n_days dimensions", {
 
 test_that("all required Stan data block variables are present", {
   dat <- make_ts_data()
-  # K600_lnorm_meanlog/sdlog are owned by specs() (see PR D-6/I1); pass
-  # distinctive marker values here to confirm prepdata_bayes_2s() just reads
-  # them through from specs rather than computing its own defaults
-  out <- prepdata_bayes_2s(dat, specs=list(K600_lnorm_meanlog=1.23, K600_lnorm_sdlog=4.56))
+  # k600_velocity_lnorm_meanlog/sdlog are owned by specs() (see PR D-6/I1);
+  # pass distinctive marker values here to confirm prepdata_bayes_2s() just
+  # reads them through from specs rather than computing its own defaults
+  out <- prepdata_bayes_2s(dat, specs=list(k600_velocity_lnorm_meanlog=1.23, k600_velocity_lnorm_sdlog=4.56))
 
   expected_names <- c(
     'n_obs','n_days','DO_obs_up','DO_sat_up','DO_obs_down','DO_sat_down',
-    'light','depth','temp_water','travel_time','K600_lnorm_meanlog','K600_lnorm_sdlog')
+    'light','depth','temp_water','travel_time',
+    'k600_velocity_lnorm_meanlog','k600_velocity_lnorm_sdlog')
   expect_true(all(expected_names %in% names(out)))
 
-  expect_equal(out$K600_lnorm_meanlog, 1.23)
-  expect_equal(out$K600_lnorm_sdlog, 4.56)
+  expect_equal(out$k600_velocity_lnorm_meanlog, 1.23)
+  expect_equal(out$k600_velocity_lnorm_sdlog, 4.56)
 })
 
 test_that("units are stripped from all numeric outputs", {
   dat <- make_ts_data(unitted=TRUE)
   expect_true(is.unitted(dat))
 
-  out <- prepdata_bayes_2s(dat, specs=list(K600_lnorm_meanlog=2.484907, K600_lnorm_sdlog=1.0))
+  out <- prepdata_bayes_2s(dat, specs=list(k600_velocity_lnorm_meanlog=log(3.48), k600_velocity_lnorm_sdlog=0.5))
   for(varname in c('DO_obs_up','DO_sat_up','DO_obs_down','DO_sat_down','light','depth','temp_water','travel_time')) {
     expect_false(is.unitted(out[[varname]]), info=varname)
   }
-  expect_false(is.unitted(out$K600_lnorm_meanlog))
-  expect_false(is.unitted(out$K600_lnorm_sdlog))
+  expect_false(is.unitted(out$k600_velocity_lnorm_meanlog))
+  expect_false(is.unitted(out$k600_velocity_lnorm_sdlog))
   expect_false(is.unitted(out$n_obs))
   expect_false(is.unitted(out$n_days))
 })
@@ -295,7 +296,7 @@ test_that("mm_align_2s() and mm_lag_light_2s() agree on day boundaries (regressi
     DO.obs.down = rep(8.8, n), DO.sat.down = rep(9.9, n),
     light = light_lag, depth = rep(0.5, n), temp.water = rep(20, n),
     travel.time = travel.time)
-  expect_silent(prepdata_bayes_2s(dat, specs=list(K600_lnorm_meanlog=2.484907, K600_lnorm_sdlog=1.0), aln=aln))
+  expect_silent(prepdata_bayes_2s(dat, specs=list(k600_velocity_lnorm_meanlog=log(3.48), k600_velocity_lnorm_sdlog=0.5), aln=aln))
 })
 
 test_that("prepdata_bayes_2s() errors clearly if a complete day's data is NA (defensive check)", {
@@ -509,10 +510,45 @@ test_that("specs(mm_name('bayes_2s')) has the expected params_in/params_out/spli
   expect_equal(
     sp$params_in,
     c('GPP_daily_mu', 'GPP_daily_sigma', 'ER_daily_mu', 'ER_daily_sigma',
-      'K600_lnorm_meanlog', 'K600_lnorm_sdlog'))
+      'k600_velocity_lnorm_meanlog', 'k600_velocity_lnorm_sdlog'))
+  # K600_daily stays in params_out even though it is no longer a fitted
+  # parameter: the model reports it as a generated quantity
   expect_equal(sp$params_out, c('GPP_daily', 'ER_daily', 'K600_daily', 'sigma', 'metab'))
   expect_false(sp$split_dates)
   expect_equal(sp$engine, 'stan')
+})
+
+test_that("specs(mm_name('bayes_2s')) defaults the gas exchange prior to the velocity scale", {
+  # the prior is on k600_velocity (m d^-1), not on a rate-scale K600 (d^-1):
+  # the model divides it by each timestep's depth. Pinning the values here
+  # so a drift back toward the one-station K600_daily_meanlog convention
+  # (log(12)), which would double-apply the depth normalization, fails loudly
+  sp <- specs(mm_name('bayes_2s'))
+  expect_equal(sp$k600_velocity_lnorm_meanlog, log(3.48))
+  expect_equal(sp$k600_velocity_lnorm_sdlog, 0.5)
+  expect_null(sp$K600_lnorm_meanlog)
+  expect_null(sp$K600_lnorm_sdlog)
+})
+
+test_that("the two-station Stan model fits a velocity-scale k600 and reports a rate-scale K600_daily", {
+  # a text-level contract test on the model file, so it costs no compile.
+  # Guards the specific error this model has already made once: a
+  # rate-scale parameter fed into a formula that divides by depth
+  stan_code <- readLines(mm_locate_filename(mm_name('bayes_2s')))
+
+  # the fitted parameter is velocity-scale, and takes the velocity-scale prior
+  expect_match(stan_code, '^\\s*vector<lower=0>\\[n_days\\] k600_velocity;', all=FALSE)
+  expect_match(stan_code, 'k600_velocity\\[i\\] ~ lognormal\\(k600_velocity_lnorm_meanlog, k600_velocity_lnorm_sdlog\\);', all=FALSE)
+  expect_false(any(grepl('K600_daily\\s*;\\s*$|\\[n_days\\] K600_daily;', stan_code[seq_len(which(grepl('^transformed parameters', stan_code))[1])])))
+
+  # depth normalization happens exactly once, on the velocity-scale parameter
+  expect_equal(sum(grepl('k600_velocity\\[t\\] / depth\\[i,t\\]', stan_code)), 1L)
+
+  # K600_daily is reported as a generated quantity, so downstream consumers
+  # (mm_na_daily(), get_params(), predict_metab()) still find it by name
+  gq_start <- which(grepl('^generated quantities', stan_code))
+  expect_length(gq_start, 1L)
+  expect_match(stan_code[gq_start:length(stan_code)], 'vector\\[n_days\\] K600_daily;', all=FALSE)
 })
 
 
@@ -883,6 +919,41 @@ test_that("metab_bayes_2s(split_dates=TRUE) fits per date and returns the joint 
   pm <- predict_metab(split)
   expect_true(all(pm$GPP > 0)); expect_true(all(pm$ER < 0)); expect_true(all(pm$K600 > 0))
   expect_false(anyDuplicated(pm$GPP) > 0)
+})
+
+test_that("reported K600_daily is the day's velocity-scale k600 divided by depth, not the prior itself", {
+  skip_on_cran()
+  skip_if_not_installed('rstan')
+
+  # The units test. A prior tight enough to dominate the likelihood pins
+  # k600_velocity at its median, so the reported K600_daily has a value that
+  # can be predicted in closed form: mean(k600 / depth) over the day's
+  # modeled timesteps. Getting the prior's own scale back instead would mean
+  # the depth division had been dropped; getting that value divided by depth
+  # a second time would mean it had been applied twice.
+  k600 <- 3.48
+  sp <- revise(fast_2station_specs(),
+               k600_velocity_lnorm_meanlog=log(k600),
+               k600_velocity_lnorm_sdlog=0.01)
+  dat <- subset_2station_days(two_station_example, 2)
+
+  mm <- suppressMessages(metab_bayes_2s(specs=sp, data=dat))
+  fit <- get_fit(mm)$daily
+
+  # the same rows the model was fitted from, so the depths match cell for cell
+  aln <- suppressMessages(mm_align_2s(v(dat), max_travel_time_hours=sp$max_travel_time_hours))
+  modeled <- mm_modeled_rows_2s(v(dat), aln)
+  expected <- vapply(
+    fit$date,
+    function(dt) mean(k600 / modeled$depth[aln$date == dt]),
+    numeric(1))
+
+  expect_equal(fit$K600_daily_50pct, expected, tolerance=0.05)
+
+  # and the scale really is distinguishable: this reach is deep enough that
+  # the rate differs from the velocity by several fold, so the assertion
+  # above would fail if the depth division went missing
+  expect_true(all(expected < k600 / 2))
 })
 
 test_that("the mcmc slot holds one stanfit jointly and a date-named list per day, as for one-station", {


### PR DESCRIPTION
Fixes a bug in the two-station Stan model: `K600_daily` was fit as a rate-scale (d⁻¹) parameter, but the transformed-parameters block still divided it by per time-step depth. 

Fitted quantity is now `k600_velocity` (m/d, day-constant), matching Bishop et al.'s VFTS reference model. The existing depth division is preserved as a transformed parameter (`K600[i,t] = k600_velocity[t] / depth[i,t]`), and a new generated quantities block averages that over each day's timesteps to produce the reported `K600_daily` (d⁻¹) — Bishop's divide-then-average method.

Prior reverted to `lognormal(meanlog=log(3.48), sdlog=0.5)`, approximating Bishop's `normal(3.48, 0.552)` on the velocity-scale parameter.

Output-side naming (`K600_daily`, `K600`/`K600.lower`/`K600.upper`) is unchanged, so `mm_na_daily()`, `predict_metab.metab_bayes_2s()`, and `format_mcmc_mat_nosplit()`'s downstream flow needed no edits.

**Verification:** 299/299 assertions pass (`test-metab_bayes_2s.R`), including three new tests (defaults pinned, Stan-file contract check, units regression test). Example fit on `two_station_example` (median depth 5.3 m) now returns `K600.daily` in the 1.15–2.56 d⁻¹ range, consistent with a 3.48 m/d prior over 2–3 m effective depths — versus the prior code's ~12 d⁻¹ nominal / ~2.3 d⁻¹ actual mismatch.